### PR TITLE
Close the pipe when the transfer exits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module acln.ro/zerocopy
+module github.com/hopehook/zerocopy
 
 go 1.12
 

--- a/zerocopy_linux.go
+++ b/zerocopy_linux.go
@@ -580,6 +580,7 @@ func transfer(dst io.Writer, src io.Reader) (int64, error) {
 	if err != nil {
 		return io.Copy(dst, src)
 	}
+	defer p.Close()
 
 	var moved int64 = 0
 	if lr != nil {

--- a/zerocopy_linux_test.go
+++ b/zerocopy_linux_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"acln.ro/zerocopy"
+	"github.com/hopehook/zerocopy"
 )
 
 func TestTeeRead(t *testing.T) {


### PR DESCRIPTION
We must close the pipe to release the file handle when transfer exits, otherwise the number of handles may overflow in high-concurrency scenarios.