### PR TITLE
Close the pipe when the transfer exits

### DIFF
--- a/zerocopy_linux.go
+++ b/zerocopy_linux.go
@@ -580,6 +580,7 @@ func transfer(dst io.Writer, src io.Reader) (int64, error) {
 	if err != nil {
 		return io.Copy(dst, src)
 	}
+	defer p.Close()
 
 	var moved int64 = 0
 	if lr != nil {


### PR DESCRIPTION
We must close the pipe to release the file handle when transfer exits, otherwise the number of handles may overflow in high-concurrency scenarios.